### PR TITLE
Enforce that files end with a newline.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,8 @@
             "ignoreRestSiblings": true
           }
         ],
-      "@typescript-eslint/no-inferrable-types": 0,
+      "eol-last": "error",
+      "@typescript-eslint/no-inferrable-types": "off",
       "@typescript-eslint/ban-ts-comment": ["error",
         {
           "ts-expect-error": "allow-with-description"


### PR DESCRIPTION
This is a minor annoyance because different editors do different things
by default. If someone's editor always ends with a newline, then every
time they touch a file in git the last line will be changed.

This just makes sure that files always end with a newline.